### PR TITLE
fix: stream chat

### DIFF
--- a/vercel-llm-api/src/vercel_ai.py
+++ b/vercel-llm-api/src/vercel_ai.py
@@ -201,4 +201,5 @@ class Client:
     headers = self.get_headers()
     
     logger.info("Waiting for response")
-    return self.stream_request(self.session.post, self.chat_url, headers=headers, json=payload)
+    for chunk in self.stream_request(self.session.post, self.chat_url, headers=headers, json=payload):
+      yield chunk


### PR DESCRIPTION
it is better to use `yield` on iter than `return`